### PR TITLE
ヘッダー固定化対応

### DIFF
--- a/2024-11-27_ダッシュボード/main.py
+++ b/2024-11-27_ダッシュボード/main.py
@@ -90,6 +90,17 @@ class ModernDataDashboard:
             padding=20,
         )
 
+        # データプレビューエリア用のヘッダコンテナ
+        self.data_header = ft.Container(
+            content=ft.Text(
+                ", ".join(["列名1", "列名2", "列名3"]),  # 実際の列名に置き換えてください
+                weight=ft.FontWeight.BOLD
+            ),
+            bgcolor=ft.colors.BLUE_50,
+            padding=10,
+            border_radius=10
+        )
+
         # データプレビューエリア
         self.data_view = ft.ListView(
             expand=True,
@@ -140,11 +151,11 @@ class ModernDataDashboard:
                         height=400
                     ),
                     
-                    # データプレビュー（右側）
+                    # データプレビュー（右側）をヘッダとデータ行に分割
                     ft.Container(
                         content=ft.Column([
-                            ft.Text("データプレビュー", size=16, weight=ft.FontWeight.BOLD),
-                            self.data_view,
+                            self.data_header,       # ヘッダを追加
+                            self.data_view,         # データ行
                         ]),
                         bgcolor=ft.colors.SURFACE_VARIANT,
                         border_radius=10,
@@ -194,6 +205,12 @@ class ModernDataDashboard:
         stats.append(ft.Text(f"行数: {len(self.df)}", size=16))
         stats.append(ft.Text(f"列数: {len(self.df.columns)}", size=16))
         
+        # ヘッダ行の更新（必要に応じて列名を動的に取得）
+        self.data_header.content = ft.Text(
+            ", ".join(self.df.columns),
+            weight=ft.FontWeight.BOLD
+        )
+        
         numeric_cols = self.df.select_dtypes(include=['int64', 'float64']).columns
         for col in numeric_cols:
             col_stats = self.df[col].describe()
@@ -211,21 +228,8 @@ class ModernDataDashboard:
             )
         self.stats_view.controls = stats
 
-        # データプレビューの更新
+        # データプレビューの更新（ヘッダは除外）
         data_rows = []
-        # ヘッダー
-        data_rows.append(
-            ft.Container(
-                content=ft.Text(
-                    ", ".join(self.df.columns),
-                    weight=ft.FontWeight.BOLD
-                ),
-                bgcolor=ft.colors.BLUE_50,
-                padding=10,
-                border_radius=10
-            )
-        )
-        # データ行
         for _, row in self.df.head(10).iterrows():
             data_rows.append(
                 ft.Container(


### PR DESCRIPTION
# データテーブルヘッダ固定化対応

## 変更内容
データテーブルのヘッダ行を固定化するために、main.py 内でヘッダ行とデータ行をそれぞれ別々のコンテナに分けます。これにより、ヘッダ行が常に表示され、データ行のみがスクロール可能になります。

### 変更点の概要（main.py）
1. `init_components` メソッドの更新:
2. `self.data_header` という新しいコンテナを追加し、ヘッダ行専用のテキストを設定しました。
3. `self.data_view` はデータ行のみを表示するように変更。
4. `create_layout` メソッドの更新:
> データプレビューエリアをヘッダコンテナとデータコンテナに分割
> これにより、ヘッダ行が固定され、データ行のみがスクロール可能になる。
5. `update_displays` メソッドの更新:
> ヘッダ行の内容を動的に更新するために、`self.data_header.content` を `self.df.columns` に基づいて設定。
6. `self.data_view.controls` にはデータ行のみを追加するように変更。

### 全体の流れ
1. ヘッダ行の固定化
> ヘッダ行を `self.data_header` に分離し、データ行を `self.data_view`.m に保持することで、ヘッダ行が常に表示され、データ行のみがスクロールされるようになります。
2. レイアウトの調整:
> `create_layout` 内で、データプレビューエリアをヘッダとデータ行のコンテナに分けて配置します。これにより、ユーザーがデータをスクロールしてもヘッダ行は固定されたままになります。
4. その他のファイルへの影響
今回の変更は main.py のみに限定されており、他のファイル (constants.py, data_processor.py, graph_view.py など) には影響を与えません。